### PR TITLE
修复使用数组的 pop 和 splice 方法操作数据时，结果错误的问题

### DIFF
--- a/content/toys/deepClone/index.js
+++ b/content/toys/deepClone/index.js
@@ -40,7 +40,12 @@ function produce(baseState, fn) {
       // 否则直接 copy[key] = newValue 的话外部拿到的对象是个 proxy
       copy[key] = isProxy(newValue) ? newValue[MY_IMMER] : newValue
       return true
-    }
+    },
+    deleteProperty(target, key) {
+      const copy = getCopy(target)
+      delete copy[key]
+      return true
+    },
   }
 
   const getProxy = data => {
@@ -99,12 +104,14 @@ const state = {
       }
     }
   },
-  data: [1]
+  data: [1, 2, 3]
 }
 
 const data = produce(state, draftState => {
   draftState.info.age = 26
   draftState.info.career.first.name = '222'
+  draftState.data.splice(0, 1)
+  draftState.data.pop()
 })
 
 console.log(data, state)


### PR DESCRIPTION
#### 问题描述：
```
// state.data = [1, 2, 3];

const data = produce(state, draftState => {
  draftState.info.age = 26
  draftState.info.career.first.name = '222'
  draftState.data.splice(0, 1)
  draftState.data.pop()
})
```
当使用如上测试用例时，会产生错误的结果，需在 trap 上添加 deleteProperty 处理解决，望采纳